### PR TITLE
feat(oauth): add redirect URIs for mcp-remote compatibility

### DIFF
--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -94,6 +94,11 @@ func (h *OAuth2Handler) HandleAuthorizationServerMetadata(w http.ResponseWriter,
 		"revocation_endpoint":                   fmt.Sprintf("%s/oauth/revoke", h.config.MCPURL),
 	}
 
+	// Add redirect URIs for mcp-remote compatibility
+	if h.config.RedirectURI != "" {
+		metadata["redirect_uris"] = []string{h.config.RedirectURI}
+	}
+
 	// Encode and send response
 	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(metadata); err != nil {


### PR DESCRIPTION

#  Problem

  The mcp-remote npm package was failing to connect to the MCP server with the error:
  Fatal error: Error: Cannot find localhost callback URI from existing client information

  The issue was that the OAuth authorization server metadata endpoint (/.well-known/oauth-authorization-server) was not advertising supported redirect URIs, which mcp-remote requires
  to discover valid callback URLs for the OAuth flow.

#  Root Cause

  The HandleAuthorizationServerMetadata function in internal/oauth/metadata.go was missing the redirect_uris field in the OAuth 2.0 Authorization Server Metadata response (RFC 8414).
  This prevented OAuth clients like mcp-remote from discovering which callback URIs are supported for the authorization code flow.

#  Solution

  Added redirect_uris field to the OAuth authorization server metadata response when OAUTH_REDIRECT_URI is configured:

  // Add redirect URIs for mcp-remote compatibility
  if h.config.RedirectURI != "" {
      metadata["redirect_uris"] = []string{h.config.RedirectURI}
  }

#  Configuration

  For this fix to work, the server must be deployed with:
  export OAUTH_REDIRECT_URI="https://<REDACT>/oauth/callback"

  Testing

  After deployment with the environment variable set, verify the fix works:
  curl https://<REDACT>/.well-known/oauth-authorization-server

  Should now include:
  {
    "redirect_uris": ["https://<REDACT>/oauth/callback"],
    ...
  }

  Impact

  - ✅ Enables mcp-remote to successfully discover callback URIs
  - ✅ Maintains backward compatibility (no redirect_uris if not configured)
  - ✅ Follows OAuth 2.0 RFC 8414 specification
  - ✅ No breaking changes to existing functionality

  This allows clients using mcp-remote to successfully complete the OAuth authorization flow with the MCP server.