### PR TITLE
feat(oauth): Add OIDC discovery endpoint for MCP client support

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -117,6 +117,9 @@ func (s *Server) ServeHTTP(port string) error {
 
 	// Add OAuth metadata endpoints for MCP compliance
 	if s.config.OAuthEnabled && s.oauthHandler != nil {
+		// OIDC Discovery endpoint (RFC 8414) - required for MCP clients (Claude Code, Desktop, claude.ai)
+		mux.HandleFunc("/.well-known/openid_configuration", s.oauthHandler.HandleOIDCDiscovery)
+
 		// RFC 8414: OAuth 2.0 Authorization Server Metadata
 		mux.HandleFunc("/.well-known/oauth-authorization-server", s.oauthHandler.HandleAuthorizationServerMetadata)
 		// RFC 9728: OAuth 2.0 Protected Resource Metadata
@@ -132,6 +135,7 @@ func (s *Server) ServeHTTP(port string) error {
 
 		// Add /callback redirect for Claude Code compatibility
 		mux.HandleFunc("/callback", s.oauthHandler.HandleCallbackRedirect)
+
 	}
 
 	// Shared MCP handler function for both endpoints

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -238,7 +238,8 @@ func (h *OAuth2Handler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.Reque
 		metadata["id_token_signing_alg_values_supported"] = []string{"HS256"}
 	case "okta", "google", "azure":
 		metadata["id_token_signing_alg_values_supported"] = []string{"RS256"}
-		metadata["jwks_uri"] = fmt.Sprintf("%s/.well-known/jwks.json", h.config.MCPURL)
+		// TODO: Implement /.well-known/jwks.json endpoint before advertising jwks_uri
+		// metadata["jwks_uri"] = fmt.Sprintf("%s/.well-known/jwks.json", h.config.MCPURL)
 	}
 
 	log.Printf("OAuth2: Returning OIDC discovery metadata for issuer: %s", h.config.MCPURL)

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -39,8 +39,15 @@ func (h *OAuth2Handler) HandleMetadata(w http.ResponseWriter, r *http.Request) {
 		"mcp_version":            "1.0.0",
 		"server_version":         h.config.Version,
 		"provider":               h.config.Provider,
-		"authorization_endpoint": fmt.Sprintf("%s://%s:%s/oauth/authorize", h.config.Scheme, h.config.MCPHost, h.config.MCPPort),
-		"token_endpoint":         h.oauth2Config.Endpoint.TokenURL,
+
+		// Add OIDC discovery fields for MCP client compatibility
+		"issuer":                   h.config.MCPURL,
+		"authorization_endpoint":   fmt.Sprintf("%s/oauth/authorize", h.config.MCPURL),
+		"token_endpoint":          fmt.Sprintf("%s/oauth/token", h.config.MCPURL),
+		"registration_endpoint":    fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
+		"response_types_supported": []string{"code"},
+		"response_modes_supported": []string{"query"},
+		"grant_types_supported":    []string{"authorization_code"},
 	}
 
 	// Add provider-specific metadata
@@ -88,10 +95,9 @@ func (h *OAuth2Handler) HandleAuthorizationServerMetadata(w http.ResponseWriter,
 		"registration_endpoint":                 fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
 		"response_types_supported":              []string{"code"},
 		"response_modes_supported":              []string{"query"},
-		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"grant_types_supported":                 []string{"authorization_code"},
 		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
 		"code_challenge_methods_supported":      []string{"plain", "S256"},
-		"revocation_endpoint":                   fmt.Sprintf("%s/oauth/revoke", h.config.MCPURL),
 	}
 
 	// Add redirect URIs for mcp-remote compatibility
@@ -192,4 +198,54 @@ func (h *OAuth2Handler) HandleCallbackRedirect(w http.ResponseWriter, r *http.Re
 		redirectURL += "?" + r.URL.RawQuery
 	}
 	http.Redirect(w, r, redirectURL, http.StatusFound)
+}
+
+// HandleOIDCDiscovery handles the OIDC discovery endpoint for MCP client compatibility
+func (h *OAuth2Handler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+
+	if r.Method != "GET" {
+		http.Error(w, `{"error":"Method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	log.Printf("OAuth2: OIDC discovery request from %s", r.RemoteAddr)
+
+	// Return OIDC Discovery metadata with existing /oauth/ endpoints
+	metadata := map[string]interface{}{
+		"issuer":                     h.config.MCPURL,
+		"authorization_endpoint":     fmt.Sprintf("%s/oauth/authorize", h.config.MCPURL),
+		"token_endpoint":            fmt.Sprintf("%s/oauth/token", h.config.MCPURL),
+		"registration_endpoint":      fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
+		"response_types_supported":   []string{"code"},
+		"response_modes_supported":   []string{"query"},
+		"grant_types_supported":      []string{"authorization_code"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
+		"code_challenge_methods_supported":      []string{"plain", "S256"},
+		"subject_types_supported":    []string{"public"},
+		"scopes_supported":          []string{"openid", "profile", "email"},
+	}
+
+	// Add provider-specific fields
+	if h.config.Audience != "" {
+		metadata["audience"] = h.config.Audience
+	}
+
+	// Add provider-specific signing algorithm information
+	switch h.config.Provider {
+	case "hmac":
+		metadata["id_token_signing_alg_values_supported"] = []string{"HS256"}
+	case "okta", "google", "azure":
+		metadata["id_token_signing_alg_values_supported"] = []string{"RS256"}
+		metadata["jwks_uri"] = fmt.Sprintf("%s/.well-known/jwks.json", h.config.MCPURL)
+	}
+
+	log.Printf("OAuth2: Returning OIDC discovery metadata for issuer: %s", h.config.MCPURL)
+
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(metadata); err != nil {
+		log.Printf("OAuth2: Error encoding OIDC discovery metadata: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
 }


### PR DESCRIPTION
# PE-7353

# Explanation

Fixes OAuth authentication failure with StreamableHTTP transport for MCP clients (Claude Code, Desktop, [claude.ai](http://claude.ai/)). The issue was missing required OIDC discovery metadata fields that caused validation errors. Added RFC 8414 compliant `/.well-known/openid_configuration` endpoint that provides all required OIDC fields including `issuer`, `authorization_endpoint`, `token_endpoint`, and `response_types_supported`. Enhanced existing metadata handlers for backward compatibility and corrected inconsistencies by removing advertisements for non-existent endpoints.

# Validation

*   ✅ Project builds successfully
*   ✅ OAuth configuration loads with proper validation
*   ✅ Server starts with OIDC provider configuration
*   ✅ OIDC discovery endpoint returns all required metadata fields
*   ✅ Provider-specific handling (HMAC vs OIDC) works correctly
*   ✅ Backward compatibility maintained with existing `mcp-remote` clients

# Additional Notes

Implementation focuses on accuracy - only advertises actually implemented OAuth capabilities. The `jwks_uri` field is intentionally omitted until the corresponding JWKS endpoint is implemented to prevent 404 errors. Maintains existing `/oauth/` endpoint structure for SSO compatibility.