### PR TITLE
fix(server): replace inline OAuth metadata with shared method call

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -259,28 +259,8 @@ func (s *Server) createMCPHandler(streamableServer *mcpserver.StreamableHTTPServ
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
 
-				// Return error response that triggers OAuth discovery
-				response := map[string]interface{}{
-					"jsonrpc": "2.0",
-					"id":      nil,
-					"error": map[string]interface{}{
-						"code":    -32600,
-						"message": "Invalid Request",
-						"data": map[string]interface{}{
-							"oauth": map[string]interface{}{
-								"issuer":                                s.oauthHandler.GetConfig().Issuer,
-								"authorization_endpoint":                fmt.Sprintf("%s/oauth2/v1/authorize", s.oauthHandler.GetConfig().Issuer),
-								"token_endpoint":                        fmt.Sprintf("%s/oauth2/v1/token", s.oauthHandler.GetConfig().Issuer),
-								"registration_endpoint":                 fmt.Sprintf("%s/oauth2/v1/clients", s.oauthHandler.GetConfig().Issuer),
-								"response_types_supported":              []string{"code"},
-								"response_modes_supported":              []string{"query"},
-								"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
-								"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
-								"code_challenge_methods_supported":      []string{"plain", "S256"},
-							},
-						},
-					},
-				}
+				// Return OAuth metadata at root level for mcp-remote 0.1.19+ compatibility
+				response := s.oauthHandler.GetAuthorizationServerMetadata()
 				_ = json.NewEncoder(w).Encode(response)
 				return
 			}

--- a/internal/oauth/metadata.go
+++ b/internal/oauth/metadata.go
@@ -88,22 +88,7 @@ func (h *OAuth2Handler) HandleAuthorizationServerMetadata(w http.ResponseWriter,
 	}
 
 	// Return OAuth 2.0 Authorization Server Metadata (RFC 8414)
-	metadata := map[string]interface{}{
-		"issuer":                                h.config.MCPURL,
-		"authorization_endpoint":                fmt.Sprintf("%s/oauth/authorize", h.config.MCPURL),
-		"token_endpoint":                        fmt.Sprintf("%s/oauth/token", h.config.MCPURL),
-		"registration_endpoint":                 fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
-		"response_types_supported":              []string{"code"},
-		"response_modes_supported":              []string{"query"},
-		"grant_types_supported":                 []string{"authorization_code"},
-		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
-		"code_challenge_methods_supported":      []string{"plain", "S256"},
-	}
-
-	// Add redirect URIs for mcp-remote compatibility
-	if h.config.RedirectURI != "" {
-		metadata["redirect_uris"] = []string{h.config.RedirectURI}
-	}
+	metadata := h.GetAuthorizationServerMetadata()
 
 	// Encode and send response
 	w.WriteHeader(http.StatusOK)
@@ -249,4 +234,26 @@ func (h *OAuth2Handler) HandleOIDCDiscovery(w http.ResponseWriter, r *http.Reque
 		log.Printf("OAuth2: Error encoding OIDC discovery metadata: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}
+}
+
+// GetAuthorizationServerMetadata returns the OAuth 2.0 Authorization Server Metadata
+func (h *OAuth2Handler) GetAuthorizationServerMetadata() map[string]interface{} {
+	metadata := map[string]interface{}{
+		"issuer":                                h.config.MCPURL,
+		"authorization_endpoint":                fmt.Sprintf("%s/oauth/authorize", h.config.MCPURL),
+		"token_endpoint":                        fmt.Sprintf("%s/oauth/token", h.config.MCPURL),
+		"registration_endpoint":                 fmt.Sprintf("%s/oauth/register", h.config.MCPURL),
+		"response_types_supported":              []string{"code"},
+		"response_modes_supported":              []string{"query"},
+		"grant_types_supported":                 []string{"authorization_code"},
+		"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
+		"code_challenge_methods_supported":      []string{"plain", "S256"},
+	}
+
+	// Add redirect URIs for mcp-remote compatibility
+	if h.config.RedirectURI != "" {
+		metadata["redirect_uris"] = []string{h.config.RedirectURI}
+	}
+
+	return metadata
 }


### PR DESCRIPTION
# PE-7353

# Explanation

Fix OAuth authentication compatibility with `mcp-remote` 0.1.19+. The issue was that `mcp-remote` 0.1.19+ introduced `discoverAuthorizationServerMetadata()` function that expects OAuth metadata in flat JSON structure, but our 401 responses returned nested JSON-RPC format. This caused Zod validation failures with "Expected string, received undefined" errors for required OAuth fields.

# Changes:

* Modified 401 response in MCP handler to return flat OAuth metadata structure instead of nested JSON-RPC format
* Added `GetAuthorizationServerMetadata()` helper function to ensure consistency between 401 responses and `.well-known` endpoints
* Maintains compatibility with both `mcp-remote` 0.1.18 (which works) and 0.1.19+ (which now works)

# Validation

* Confirmed `mcp-remote` 0.1.18 works with existing server
* Identified `mcp-remote` 0.1.19+ fails with Zod validation on OAuth metadata discovery
* Verified `WWW-Authenticate` header and OAuth endpoints return consistent metadata
* Build succeeds and maintains backward compatibility with standard MCP clients

# Additional Notes

Standard MCP clients expect HTTP 401 + `WWW-Authenticate` header for OAuth discovery per MCP specification, not necessarily JSON-RPC format. This change aligns with both MCP spec requirements and `mcp-remote` client expectations.