### PR TITLE
fix(server): use MCPURL from OAuth config for 401 challenges

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -249,13 +249,12 @@ func (s *Server) createMCPHandler(streamableServer *mcpserver.StreamableHTTPServ
 				// Return 401 with OAuth discovery information
 				log.Printf("OAuth: No bearer token provided, returning 401 with discovery info")
 
-				// Use MCP server host/port, not Trino
-				mcpHost := getEnv("MCP_HOST", "localhost")
-				mcpPort := getEnv("MCP_PORT", "8080")
+				// Use consistent MCP URL from OAuth handler configuration
+				mcpURL := s.oauthHandler.GetConfig().MCPURL
 
 				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s", authorization_uri="%s/.well-known/oauth-authorization-server"`,
-					mcpHost,
-					fmt.Sprintf("%s://%s:%s", s.getScheme(), mcpHost, mcpPort)))
+					mcpURL,
+					mcpURL))
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnauthorized)
 


### PR DESCRIPTION
# PE-7353

# Explanation

Fix OAuth authentication compatibility with `mcp-remote 0.1.19+` by addressing two issues:

1. Response Structure: Modified MCP handler's 401 response to return flat OAuth metadata instead of nested JSON-RPC structure. `mcp-remote 0.1.19+` introduced
   `discoverAuthorizationServerMetadata()` function that expects OAuth fields at root level for Zod validation.
2. URL Consistency: Fixed `WWW-Authenticate` header to use the same `MCPURL` as OAuth metadata responses instead of constructing URLs from `MCP_HOST`/`MCP_PORT` environment
   variables. This prevents mismatches between discovery URLs and actual OAuth endpoints.

# Changes:

* Added `GetAuthorizationServerMetadata()` helper function for consistent OAuth metadata across all endpoints
* Updated 401 response to use flat structure with OAuth handler's metadata
* Fixed `WWW-Authenticate` header to use consistent `MCPURL` source

# Validation

* Confirmed `mcp-remote 0.1.18` works with existing implementation
* Identified `mcp-remote 0.1.19+` fails with Zod validation errors on OAuth discovery
* Verified deployed server was returning `0.0.0.0:8080` in `WWW-Authenticate` header causing discovery failures
* Build succeeds and maintains backward compatibility with standard MCP clients

# Additional Notes

The fix ensures both `mcp-remote` versions work while maintaining MCP specification compliance. Standard MCP clients expect HTTP 401 + `WWW-Authenticate` header for
OAuth discovery, which this change preserves while adding the flat metadata structure that newer `mcp-remote` versions require.