### PR TITLE
refactor(oauth): add security headers and enhance success page

### DIFF
--- a/internal/oauth/handlers.go
+++ b/internal/oauth/handlers.go
@@ -411,22 +411,29 @@ func (h *OAuth2Handler) HandleToken(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// showSuccessPage displays a success page with debug information
+// showSuccessPage displays a success page after OAuth completion
 func (h *OAuth2Handler) showSuccessPage(w http.ResponseWriter, code, state string) {
-	w.Header().Set("Content-Type", "text/html")
+	// Log authorization details server-side (truncated for security)
+	log.Printf("OAuth2: Authorization successful - code: %s, state: %s",
+		truncateString(code, 10), truncateString(state, 10))
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprintf(w, `
-		<html>
-		<head><title>OAuth2 Success</title></head>
+	_, _ = fmt.Fprintf(w, `<!DOCTYPE html>
+		<html lang="en">
+		<head>
+			<meta charset="utf-8">
+			<meta name="viewport" content="width=device-width, initial-scale=1">
+			<title>OAuth2 Success</title>
+		</head>
 		<body>
 			<h2>Authentication Successful!</h2>
 			<p>You have been successfully authenticated.</p>
-			<p>Authorization code: %s</p>
-			<p>State: %s</p>
 			<p>You can now close this window and return to your application.</p>
 		</body>
-		</html>
-	`, code, state)
+		</html>`)
 }
 
 // truncateString safely truncates a string for logging

--- a/internal/oauth/providers.go
+++ b/internal/oauth/providers.go
@@ -172,7 +172,7 @@ func (v *OIDCValidator) Initialize(cfg *config.TrinoConfig) error {
 	
 	// Configure token verifier with required validation settings
 	verifier := provider.Verifier(&oidc.Config{
-		ClientID:             cfg.OIDCClientID,
+		ClientID:             cfg.OIDCAudience, // Note: go-oidc uses ClientID field for audience validation - see https://github.com/coreos/go-oidc/blob/v3/oidc/verify.go#L85
 		SupportedSigningAlgs: []string{oidc.RS256, oidc.ES256},
 		SkipClientIDCheck:    false, // Always validate if ClientID is provided
 		SkipExpiryCheck:      false, // Verify expiration


### PR DESCRIPTION
# PE-7353

## Explanation

Fixes OAuth audience validation bug where the `go-oidc` library was configured to use `ClientID` instead of the configured audience value. The `go-oidc` `Config.ClientID` field is used for audience validation, not client identification, causing tokens to be rejected despite correct server configuration.


## Additional Notes

This resolves the contradiction between server logs showing correct audience configuration and actual validation failures. The `go-oidc` library's naming convention is misleading - `ClientID` field performs audience validation.