### PR TITLE
Pe 7414 trino oauth enhancement

### DIFF
--- a/charts/mcp-trino/templates/configmap.yaml
+++ b/charts/mcp-trino/templates/configmap.yaml
@@ -27,11 +27,13 @@ data:
   {{- if .Values.trino.allowlists.tables }}
   TRINO_ALLOWED_TABLES: {{ .Values.trino.allowlists.tables | join "," | quote }}
   {{- end }}
-  TRINO_OAUTH_ENABLED: {{ .Values.trino.oauth.enabled | quote }}
+  OAUTH_ENABLED: {{ .Values.trino.oauth.enabled | quote }}
   {{- if .Values.trino.oauth.enabled }}
+  OAUTH_MODE: {{ .Values.trino.oauth.mode | quote }}
   OAUTH_PROVIDER: {{ .Values.trino.oauth.provider | quote }}
-  {{- if .Values.trino.oauth.redirectURI }}
-  OAUTH_REDIRECT_URI: {{ .Values.trino.oauth.redirectURI | quote }}
+  {{- if .Values.trino.oauth.redirectURIs }}
+  OAUTH_REDIRECT_URI: {{ .Values.trino.oauth.redirectURIs | quote }}
+  OAUTH_ALLOWED_REDIRECT_URIS: {{ .Values.trino.oauth.redirectURIs | quote }}
   {{- end }}
   {{- if .Values.trino.oauth.oidc.issuer }}
   OIDC_ISSUER: {{ .Values.trino.oauth.oidc.issuer | quote }}

--- a/charts/mcp-trino/values.yaml
+++ b/charts/mcp-trino/values.yaml
@@ -73,10 +73,11 @@ trino:
   # OAuth 2.1 configuration
   oauth:
     enabled: false
+    mode: "native"  # native or proxy
     provider: "hmac"  # hmac, okta, google, azure
     jwtSecret: ""
-    redirectURI: ""
-    
+    redirectURIs: ""  # Single redirect URI or comma-separated list for proxy mode
+
     # OIDC configuration
     oidc:
       issuer: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,15 +22,17 @@ services:
       dockerfile: Dockerfile
     container_name: trino-mcp
     ports:
-      - '8080:8080'
+      - '8081:8080'
     environment:
       - TRINO_HOST=trino
       - TRINO_PORT=8080
       - TRINO_USER=trino
       - TRINO_CATALOG=memory
       - TRINO_SCHEMA=default
+      - TRINO_SCHEME=http
       - MCP_TRANSPORT=http
       - MCP_PORT=8080
+      - TRINO_ALLOWED_SCHEMAS=memory.analytics,memory.marts,memory.staging
     depends_on:
       trino:
         condition: service_healthy

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,18 +64,21 @@ func TestNewTrinoConfigWithAllowlists(t *testing.T) {
 	originalCatalogs := os.Getenv("TRINO_ALLOWED_CATALOGS")
 	originalSchemas := os.Getenv("TRINO_ALLOWED_SCHEMAS")
 	originalTables := os.Getenv("TRINO_ALLOWED_TABLES")
+	originalOAuth := os.Getenv("OAUTH_ENABLED")
 
 	// Clean up after test
 	defer func() {
 		_ = os.Setenv("TRINO_ALLOWED_CATALOGS", originalCatalogs)
 		_ = os.Setenv("TRINO_ALLOWED_SCHEMAS", originalSchemas)
 		_ = os.Setenv("TRINO_ALLOWED_TABLES", originalTables)
+		_ = os.Setenv("OAUTH_ENABLED", originalOAuth)
 	}()
 
 	// Test with allowlists configured
 	_ = os.Setenv("TRINO_ALLOWED_CATALOGS", "hive,postgresql")
 	_ = os.Setenv("TRINO_ALLOWED_SCHEMAS", "hive.analytics,postgresql.public")
 	_ = os.Setenv("TRINO_ALLOWED_TABLES", "hive.analytics.users")
+	_ = os.Setenv("OAUTH_ENABLED", "false") // Disable OAuth for this test
 
 	config, err := NewTrinoConfig()
 	if err != nil {
@@ -103,18 +106,21 @@ func TestNewTrinoConfigWithoutAllowlists(t *testing.T) {
 	originalCatalogs := os.Getenv("TRINO_ALLOWED_CATALOGS")
 	originalSchemas := os.Getenv("TRINO_ALLOWED_SCHEMAS")
 	originalTables := os.Getenv("TRINO_ALLOWED_TABLES")
+	originalOAuth := os.Getenv("OAUTH_ENABLED")
 
 	// Clean up after test
 	defer func() {
 		_ = os.Setenv("TRINO_ALLOWED_CATALOGS", originalCatalogs)
 		_ = os.Setenv("TRINO_ALLOWED_SCHEMAS", originalSchemas)
 		_ = os.Setenv("TRINO_ALLOWED_TABLES", originalTables)
+		_ = os.Setenv("OAUTH_ENABLED", originalOAuth)
 	}()
 
 	// Clear allowlist environment variables
 	_ = os.Unsetenv("TRINO_ALLOWED_CATALOGS")
 	_ = os.Unsetenv("TRINO_ALLOWED_SCHEMAS")
 	_ = os.Unsetenv("TRINO_ALLOWED_TABLES")
+	_ = os.Setenv("OAUTH_ENABLED", "false") // Disable OAuth for this test
 
 	config, err := NewTrinoConfig()
 	if err != nil {
@@ -201,11 +207,13 @@ func TestNewTrinoConfigMalformedAllowlist(t *testing.T) {
 	// Save original environment
 	originalSchemas := os.Getenv("TRINO_ALLOWED_SCHEMAS")
 	originalTables := os.Getenv("TRINO_ALLOWED_TABLES")
+	originalOAuth := os.Getenv("OAUTH_ENABLED")
 
 	// Clean up after test
 	defer func() {
 		_ = os.Setenv("TRINO_ALLOWED_SCHEMAS", originalSchemas)
 		_ = os.Setenv("TRINO_ALLOWED_TABLES", originalTables)
+		_ = os.Setenv("OAUTH_ENABLED", originalOAuth)
 	}()
 
 	tests := []struct {
@@ -237,6 +245,7 @@ func TestNewTrinoConfigMalformedAllowlist(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_ = os.Setenv(tt.envVar, tt.value)
+			_ = os.Setenv("OAUTH_ENABLED", "false") // Disable OAuth for this test
 			_, err := NewTrinoConfig()
 
 			if err == nil {

--- a/internal/config/oauth_test.go
+++ b/internal/config/oauth_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestOAuthModeConfiguration(t *testing.T) {
+	// Save original environment
+	origOAuthMode := os.Getenv("OAUTH_MODE")
+	origOAuthEnabled := os.Getenv("OAUTH_ENABLED")
+	origOAuthProvider := os.Getenv("OAUTH_PROVIDER")
+
+	// Clean up after test
+	defer func() {
+		_ = os.Setenv("OAUTH_MODE", origOAuthMode)
+		_ = os.Setenv("OAUTH_ENABLED", origOAuthEnabled)
+		_ = os.Setenv("OAUTH_PROVIDER", origOAuthProvider)
+	}()
+
+	tests := []struct {
+		name           string
+		oauthMode      string
+		oauthEnabled   string
+		oauthProvider  string
+		expectedMode   string
+		expectError    bool
+		expectedEnable bool
+	}{
+		{
+			name:           "Default native mode",
+			oauthMode:      "native",
+			oauthEnabled:   "false",
+			oauthProvider:  "",
+			expectedMode:   "native",
+			expectError:    false,
+			expectedEnable: false,
+		},
+		{
+			name:           "Explicit native mode with HMAC",
+			oauthMode:      "native",
+			oauthEnabled:   "true",
+			oauthProvider:  "hmac",
+			expectedMode:   "native",
+			expectError:    true, // JWT_SECRET required for HMAC
+			expectedEnable: true,
+		},
+		{
+			name:           "Proxy mode with HMAC",
+			oauthMode:      "proxy",
+			oauthEnabled:   "true",
+			oauthProvider:  "hmac",
+			expectedMode:   "proxy",
+			expectError:    true, // JWT_SECRET required for HMAC
+			expectedEnable: true,
+		},
+		{
+			name:          "Invalid mode",
+			oauthMode:     "invalid",
+			oauthEnabled:  "false",
+			oauthProvider: "",
+			expectedMode:  "",
+			expectError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv("OAUTH_MODE", tt.oauthMode)
+			_ = os.Setenv("OAUTH_ENABLED", tt.oauthEnabled)
+			_ = os.Setenv("OAUTH_PROVIDER", tt.oauthProvider)
+
+			// Set JWT_SECRET for HMAC tests that shouldn't error
+			if tt.oauthProvider == "hmac" && !tt.expectError {
+				_ = os.Setenv("JWT_SECRET", "test-secret")
+			} else {
+				_ = os.Unsetenv("JWT_SECRET")
+			}
+
+			config, err := NewTrinoConfig()
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if config.OAuthMode != tt.expectedMode {
+				t.Errorf("OAuthMode = %s, expected %s", config.OAuthMode, tt.expectedMode)
+			}
+
+			if config.OAuthEnabled != tt.expectedEnable {
+				t.Errorf("OAuthEnabled = %t, expected %t", config.OAuthEnabled, tt.expectedEnable)
+			}
+		})
+	}
+}
+
+func TestOAuthAllowedRedirectsConfiguration(t *testing.T) {
+	// Save original environment
+	origRedirects := os.Getenv("OAUTH_ALLOWED_REDIRECT_URIS")
+	origOAuthEnabled := os.Getenv("OAUTH_ENABLED")
+
+	// Clean up after test
+	defer func() {
+		_ = os.Setenv("OAUTH_ALLOWED_REDIRECT_URIS", origRedirects)
+		_ = os.Setenv("OAUTH_ENABLED", origOAuthEnabled)
+	}()
+
+	tests := []struct {
+		name              string
+		allowedRedirects  string
+		expectedRedirects string
+	}{
+		{
+			name:              "No redirects configured",
+			allowedRedirects:  "",
+			expectedRedirects: "",
+		},
+		{
+			name:              "Single redirect URI",
+			allowedRedirects:  "https://client.example.com/callback",
+			expectedRedirects: "https://client.example.com/callback",
+		},
+		{
+			name:              "Multiple redirect URIs",
+			allowedRedirects:  "https://client1.example.com/callback,https://client2.example.com/callback",
+			expectedRedirects: "https://client1.example.com/callback,https://client2.example.com/callback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = os.Setenv("OAUTH_ALLOWED_REDIRECT_URIS", tt.allowedRedirects)
+			_ = os.Setenv("OAUTH_ENABLED", "false") // Disable OAuth to avoid validation errors
+			_ = os.Setenv("OAUTH_MODE", "native") // Set explicit mode to avoid validation errors
+
+			config, err := NewTrinoConfig()
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+				return
+			}
+
+			if config.OAuthRedirectURIs != tt.expectedRedirects {
+				t.Errorf("OAuthRedirectURIs = %s, expected %s", config.OAuthRedirectURIs, tt.expectedRedirects)
+			}
+		})
+	}
+}
+
+func TestOAuthProxyModeValidation(t *testing.T) {
+	// Save original environment
+	origMode := os.Getenv("OAUTH_MODE")
+	origEnabled := os.Getenv("OAUTH_ENABLED")
+	origProvider := os.Getenv("OAUTH_PROVIDER")
+	origClientSecret := os.Getenv("OIDC_CLIENT_SECRET")
+	origAllowedRedirects := os.Getenv("OAUTH_ALLOWED_REDIRECT_URIS")
+	origIssuer := os.Getenv("OIDC_ISSUER")
+	origAudience := os.Getenv("OIDC_AUDIENCE")
+
+	// Clean up after test
+	defer func() {
+		_ = os.Setenv("OAUTH_MODE", origMode)
+		_ = os.Setenv("OAUTH_ENABLED", origEnabled)
+		_ = os.Setenv("OAUTH_PROVIDER", origProvider)
+		_ = os.Setenv("OIDC_CLIENT_SECRET", origClientSecret)
+		_ = os.Setenv("OAUTH_ALLOWED_REDIRECT_URIS", origAllowedRedirects)
+		_ = os.Setenv("OIDC_ISSUER", origIssuer)
+		_ = os.Setenv("OIDC_AUDIENCE", origAudience)
+	}()
+
+	// Set up proxy mode with OIDC provider
+	_ = os.Setenv("OAUTH_MODE", "proxy")
+	_ = os.Setenv("OAUTH_ENABLED", "true")
+	_ = os.Setenv("OAUTH_PROVIDER", "okta")
+	_ = os.Setenv("OIDC_ISSUER", "https://dev.okta.com")
+	_ = os.Setenv("OIDC_AUDIENCE", "https://example.com")
+	_ = os.Setenv("OIDC_CLIENT_SECRET", "")  // Missing client secret
+	_ = os.Setenv("OAUTH_ALLOWED_REDIRECT_URIS", "") // Missing allowed redirects
+
+	config, err := NewTrinoConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+
+	if config.OAuthMode != "proxy" {
+		t.Errorf("Expected proxy mode, got %s", config.OAuthMode)
+	}
+
+	if config.OAuthEnabled != true {
+		t.Errorf("Expected OAuth enabled")
+	}
+}

--- a/internal/oauth/metadata_test.go
+++ b/internal/oauth/metadata_test.go
@@ -1,0 +1,228 @@
+package oauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetAuthorizationServerMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		provider string
+		issuer   string
+		mcpURL   string
+		checkFields []string
+	}{
+		{
+			name:     "Native mode with Okta",
+			mode:     "native",
+			provider: "okta",
+			issuer:   "https://dev.okta.com",
+			mcpURL:   "https://mcp.example.com",
+			checkFields: []string{"issuer", "authorization_endpoint", "token_endpoint", "jwks_uri"},
+		},
+		{
+			name:     "Native mode with Google",
+			mode:     "native",
+			provider: "google",
+			issuer:   "https://accounts.google.com",
+			mcpURL:   "https://mcp.example.com",
+			checkFields: []string{"issuer", "authorization_endpoint", "token_endpoint", "jwks_uri"},
+		},
+		{
+			name:     "Proxy mode",
+			mode:     "proxy",
+			provider: "okta",
+			issuer:   "https://dev.okta.com",
+			mcpURL:   "https://mcp.example.com",
+			checkFields: []string{"issuer", "authorization_endpoint", "token_endpoint", "jwks_uri"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &OAuth2Config{
+				Mode:     tt.mode,
+				Provider: tt.provider,
+				Issuer:   tt.issuer,
+				MCPURL:   tt.mcpURL,
+			}
+			handler := &OAuth2Handler{config: config}
+
+			metadata := handler.GetAuthorizationServerMetadata()
+
+			// Check that required fields are present
+			for _, field := range tt.checkFields {
+				if _, exists := metadata[field]; !exists {
+					t.Errorf("Missing required field: %s", field)
+				}
+			}
+
+			// Verify mode-specific behavior
+			issuer := metadata["issuer"].(string)
+			authEndpoint := metadata["authorization_endpoint"].(string)
+
+			if tt.mode == "native" {
+				// Native mode should point to OAuth provider
+				if issuer != tt.issuer {
+					t.Errorf("Native mode issuer = %s, expected %s", issuer, tt.issuer)
+				}
+				if tt.provider == "okta" {
+					expectedAuth := tt.issuer + "/oauth2/v1/authorize"
+					if authEndpoint != expectedAuth {
+						t.Errorf("Native mode auth endpoint = %s, expected %s", authEndpoint, expectedAuth)
+					}
+				}
+			} else {
+				// Proxy mode should point to MCP server
+				if issuer != tt.mcpURL {
+					t.Errorf("Proxy mode issuer = %s, expected %s", issuer, tt.mcpURL)
+				}
+				expectedAuth := tt.mcpURL + "/oauth/authorize"
+				if authEndpoint != expectedAuth {
+					t.Errorf("Proxy mode auth endpoint = %s, expected %s", authEndpoint, expectedAuth)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleAuthorizationServerMetadata(t *testing.T) {
+	config := &OAuth2Config{
+		Mode:     "native",
+		Provider: "okta",
+		Issuer:   "https://dev.okta.com",
+		MCPURL:   "https://mcp.example.com",
+	}
+	handler := &OAuth2Handler{config: config}
+
+	tests := []struct {
+		name           string
+		method         string
+		expectedStatus int
+	}{
+		{"GET request", "GET", http.StatusOK},
+		{"HEAD request", "HEAD", http.StatusOK},
+		{"OPTIONS request", "OPTIONS", http.StatusOK},
+		{"POST request", "POST", http.StatusMethodNotAllowed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, "/.well-known/oauth-authorization-server", nil)
+
+			handler.HandleAuthorizationServerMetadata(recorder, req)
+
+			if recorder.Code != tt.expectedStatus {
+				t.Errorf("Status = %d, expected %d", recorder.Code, tt.expectedStatus)
+			}
+
+			// Check CORS headers are present
+			if origin := recorder.Header().Get("Access-Control-Allow-Origin"); origin != "*" {
+				t.Errorf("CORS Allow-Origin = %s, expected *", origin)
+			}
+
+			if tt.method == "GET" {
+				// Verify JSON response
+				var metadata map[string]interface{}
+				if err := json.Unmarshal(recorder.Body.Bytes(), &metadata); err != nil {
+					t.Errorf("Failed to parse JSON response: %v", err)
+				}
+
+				if issuer, exists := metadata["issuer"]; !exists {
+					t.Errorf("Missing issuer field in metadata")
+				} else if issuer != config.Issuer {
+					t.Errorf("Issuer = %s, expected %s", issuer, config.Issuer)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleProtectedResourceMetadata(t *testing.T) {
+	config := &OAuth2Config{
+		Issuer: "https://dev.okta.com",
+		MCPURL: "https://mcp.example.com",
+	}
+	handler := &OAuth2Handler{config: config}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+
+	handler.HandleProtectedResourceMetadata(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Status = %d, expected %d", recorder.Code, http.StatusOK)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &metadata); err != nil {
+		t.Errorf("Failed to parse JSON response: %v", err)
+	}
+
+	// Check required fields
+	if resource := metadata["resource"]; resource != config.MCPURL {
+		t.Errorf("Resource = %s, expected %s", resource, config.MCPURL)
+	}
+
+	authServers, exists := metadata["authorization_servers"]
+	if !exists {
+		t.Errorf("Missing authorization_servers field")
+	} else {
+		servers := authServers.([]interface{})
+		if len(servers) != 1 || servers[0] != config.Issuer {
+			t.Errorf("Authorization servers = %v, expected [%s]", servers, config.Issuer)
+		}
+	}
+}
+
+func TestHandleOIDCDiscovery(t *testing.T) {
+	config := &OAuth2Config{
+		MCPURL:   "https://mcp.example.com",
+		Provider: "okta",
+		Audience: "https://api.example.com",
+	}
+	handler := &OAuth2Handler{config: config}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/.well-known/openid_configuration", nil)
+
+	handler.HandleOIDCDiscovery(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Errorf("Status = %d, expected %d", recorder.Code, http.StatusOK)
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &metadata); err != nil {
+		t.Errorf("Failed to parse JSON response: %v", err)
+	}
+
+	// Check required OIDC fields
+	requiredFields := []string{
+		"issuer",
+		"authorization_endpoint",
+		"token_endpoint",
+		"response_types_supported",
+		"subject_types_supported",
+		"id_token_signing_alg_values_supported",
+	}
+
+	for _, field := range requiredFields {
+		if _, exists := metadata[field]; !exists {
+			t.Errorf("Missing required OIDC field: %s", field)
+		}
+	}
+
+	if issuer := metadata["issuer"]; issuer != config.MCPURL {
+		t.Errorf("OIDC issuer = %s, expected %s", issuer, config.MCPURL)
+	}
+
+	if audience := metadata["audience"]; audience != config.Audience {
+		t.Errorf("OIDC audience = %s, expected %s", audience, config.Audience)
+	}
+}

--- a/internal/oauth/security_test.go
+++ b/internal/oauth/security_test.go
@@ -1,0 +1,267 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRedirectURIValidation(t *testing.T) {
+	tests := []struct {
+		name             string
+		allowedRedirects string
+		testURI          string
+		expected         bool
+	}{
+		{
+			name:             "No allowlist configured - reject all",
+			allowedRedirects: "",
+			testURI:          "https://client.example.com/callback",
+			expected:         false,
+		},
+		{
+			name:             "Single URI match",
+			allowedRedirects: "https://client.example.com/callback",
+			testURI:          "https://client.example.com/callback",
+			expected:         true,
+		},
+		{
+			name:             "Multiple URIs - first match",
+			allowedRedirects: "https://client1.example.com/callback,https://client2.example.com/callback",
+			testURI:          "https://client1.example.com/callback",
+			expected:         true,
+		},
+		{
+			name:             "Multiple URIs - second match",
+			allowedRedirects: "https://client1.example.com/callback,https://client2.example.com/callback",
+			testURI:          "https://client2.example.com/callback",
+			expected:         true,
+		},
+		{
+			name:             "No match",
+			allowedRedirects: "https://client1.example.com/callback",
+			testURI:          "https://malicious.example.com/callback",
+			expected:         false,
+		},
+		{
+			name:             "Partial match rejected",
+			allowedRedirects: "https://client.example.com/callback",
+			testURI:          "https://client.example.com/callback/evil",
+			expected:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &OAuth2Config{
+				RedirectURIs: tt.allowedRedirects,
+			}
+			handler := &OAuth2Handler{config: config}
+
+			result := handler.isValidRedirectURI(tt.testURI)
+			if result != tt.expected {
+				t.Errorf("isValidRedirectURI(%q) = %v, expected %v", tt.testURI, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestOAuthParameterValidation(t *testing.T) {
+	handler := &OAuth2Handler{}
+
+	tests := []struct {
+		name        string
+		params      map[string]string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "Valid parameters",
+			params: map[string]string{
+				"code":           "valid_code_123",
+				"state":          "valid_state",
+				"code_challenge": "valid_challenge",
+			},
+			expectError: false,
+		},
+		{
+			name: "Code too long",
+			params: map[string]string{
+				"code": strings.Repeat("a", 513), // 513 characters
+			},
+			expectError: true,
+			errorMsg:    "invalid code parameter length",
+		},
+		{
+			name: "State too long",
+			params: map[string]string{
+				"state": strings.Repeat("a", 257), // 257 characters
+			},
+			expectError: true,
+			errorMsg:    "invalid state parameter length",
+		},
+		{
+			name: "Code challenge too long",
+			params: map[string]string{
+				"code_challenge": strings.Repeat("a", 257), // 257 characters
+			},
+			expectError: true,
+			errorMsg:    "invalid code_challenge parameter length",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a form request with the test parameters
+			values := make([]string, 0, len(tt.params)*2)
+			for key, value := range tt.params {
+				values = append(values, key, value)
+			}
+
+			req := httptest.NewRequest("POST", "/test", strings.NewReader(""))
+			req.Form = make(map[string][]string)
+			for i := 0; i < len(values); i += 2 {
+				req.Form[values[i]] = []string{values[i+1]}
+			}
+
+			err := handler.validateOAuthParams(req)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error but got none")
+				} else if !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error containing %q, got %q", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSecurityHeaders(t *testing.T) {
+	handler := &OAuth2Handler{}
+	recorder := httptest.NewRecorder()
+
+	handler.addSecurityHeaders(recorder)
+
+	expectedHeaders := map[string]string{
+		"X-Content-Type-Options": "nosniff",
+		"X-Frame-Options":        "DENY",
+		"Cache-Control":          "no-store, no-cache, max-age=0",
+		"Pragma":                 "no-cache",
+	}
+
+	for header, expectedValue := range expectedHeaders {
+		actualValue := recorder.Header().Get(header)
+		if actualValue != expectedValue {
+			t.Errorf("Header %s = %q, expected %q", header, actualValue, expectedValue)
+		}
+	}
+}
+
+func TestHTTPSEnforcementInHandlers(t *testing.T) {
+	config := &OAuth2Config{
+		Mode: "proxy",
+	}
+	handler := &OAuth2Handler{config: config}
+
+	endpoints := []struct {
+		name    string
+		handler func(http.ResponseWriter, *http.Request)
+	}{
+		{"HandleAuthorize", handler.HandleAuthorize},
+		{"HandleCallback", handler.HandleCallback},
+		{"HandleToken", handler.HandleToken},
+	}
+
+	for _, endpoint := range endpoints {
+		t.Run("Native mode blocks "+endpoint.name, func(t *testing.T) {
+			// Test native mode blocking
+			nativeConfig := &OAuth2Config{Mode: "native"}
+			nativeHandler := &OAuth2Handler{config: nativeConfig}
+
+			var testHandler func(http.ResponseWriter, *http.Request)
+			switch endpoint.name {
+			case "HandleAuthorize":
+				testHandler = nativeHandler.HandleAuthorize
+			case "HandleCallback":
+				testHandler = nativeHandler.HandleCallback
+			case "HandleToken":
+				testHandler = nativeHandler.HandleToken
+			}
+
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/test", nil)
+
+			testHandler(recorder, req)
+
+			if recorder.Code != http.StatusNotFound {
+				t.Errorf("%s in native mode should return 404, got %d", endpoint.name, recorder.Code)
+			}
+
+			body := recorder.Body.String()
+			if !strings.Contains(body, "OAuth proxy disabled in native mode") {
+				t.Errorf("%s should return OAuth proxy disabled message", endpoint.name)
+			}
+		})
+	}
+}
+
+func TestJWKSProxyMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     string
+		provider string
+		expected int
+	}{
+		{
+			name:     "Native mode blocks JWKS",
+			mode:     "native",
+			provider: "okta",
+			expected: http.StatusNotFound,
+		},
+		{
+			name:     "HMAC provider returns empty JWKS",
+			mode:     "proxy",
+			provider: "hmac",
+			expected: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &OAuth2Config{
+				Mode:     tt.mode,
+				Provider: tt.provider,
+			}
+			handler := &OAuth2Handler{config: config}
+
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/.well-known/jwks.json", nil)
+
+			handler.HandleJWKS(recorder, req)
+
+			if recorder.Code != tt.expected {
+				t.Errorf("Expected status %d, got %d", tt.expected, recorder.Code)
+			}
+
+			if tt.mode == "native" {
+				body := recorder.Body.String()
+				if !strings.Contains(body, "JWKS endpoint disabled in native mode") {
+					t.Errorf("Should return JWKS disabled message in native mode")
+				}
+			}
+
+			if tt.provider == "hmac" && tt.mode == "proxy" {
+				body := recorder.Body.String()
+				if body != `{"keys":[]}` {
+					t.Errorf("HMAC provider should return empty JWKS, got %s", body)
+				}
+			}
+		})
+	}
+}

--- a/trino-conf/config.properties
+++ b/trino-conf/config.properties
@@ -1,4 +1,5 @@
 coordinator=true
 node-scheduler.include-coordinator=true
 http-server.http.port=8080
-discovery.uri=http://localhost:8080 
+discovery.uri=http://localhost:8080
+node.environment=test 


### PR DESCRIPTION
PE-7414

# Explanation

Refactor OAuth environment variable naming from `TRINO_OAUTH_ENABLED` to `OAUTH_ENABLED` to better reflect that OAuth authentication is for MCP server access, not Trino database authentication. Additionally, merge redundant redirect URI configuration fields (`OAuthRedirectURI` + `OAuthAllowedRedirects`) into a single unified field (`OAuthRedirectURIs`) that handles both single fixed redirect URIs and comma-separated allowlists.

# Key Changes:

*   Renamed `TRINO_OAUTH_ENABLED` → `OAUTH_ENABLED` throughout codebase
*   Merged `OAuthRedirectURI` + `OAuthAllowedRedirects` → `OAuthRedirectURIs`
*   Updated Helm charts to support new environment variable naming
*   Enhanced HTTPS enforcement to work behind reverse proxies via `X-Forwarded-Proto` header
*   Added comprehensive OAuth configuration guide to documentation
*   Fixed error handling in tests to satisfy linting requirements

# Validation

1.  All unit tests pass (`go test ./... -short`)
2.  Linting passes with zero issues (`make lint`)
3.  Configuration backwards compatibility maintained (reads from both old and new env vars with warnings)
4.  Helm chart templates updated to use unified redirect URI field
5.  Documentation fact-checked against actual implementation to remove unsupported JWT client assertion claims

# Additional Notes

Environment variable transition includes warning logs when both old and new variables are set with different values to aid in migration. The unified redirect URI field automatically detects single vs. multiple URIs based on comma presence, simplifying configuration while maintaining security.