### PR TITLE
[PE-7844] send per-query user identity to Trino

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 WORKDIR /app
 
 # Install build dependencies in a separate layer for better caching
+RUN apk update
 RUN apk add --no-cache git
 
 # Copy go mod and sum files first (better layer caching)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Use a small image for the final container (explicit target platform)
 FROM --platform=$TARGETPLATFORM alpine:latest
-RUN apk update
-RUN apk --no-cache add ca-certificates
+RUN apk update && apk --no-cache add ca-certificates
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 WORKDIR /app
 
 # Install build dependencies in a separate layer for better caching
-RUN apk update
 RUN apk add --no-cache git
 
 # Copy go mod and sum files first (better layer caching)
@@ -30,7 +29,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 
 # Use a small image for the final container (explicit target platform)
 FROM --platform=$TARGETPLATFORM alpine:latest
-
+RUN apk update
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -ldflags="-w -s" -trimpath -o trino-mcp ./cmd/
 
 # Use a small image for the final container (explicit target platform)
-FROM --platform=$TARGETPLATFORM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:3.22.2
 RUN apk update && apk --no-cache add ca-certificates
 
 WORKDIR /app

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"strings"
@@ -42,7 +43,7 @@ func main() {
 
 	// Test connection by listing catalogs
 	log.Println("Testing Trino connection...")
-	catalogs, err := trinoClient.ListCatalogs()
+	catalogs, err := trinoClient.ListCatalogs(context.Background())
 	if err != nil {
 		log.Fatalf("Failed to connect to Trino: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Vungle/mcp-trino
 go 1.24.11
 
 require (
-	github.com/Vungle/oauth-mcp-proxy v1.0.2
+	github.com/Vungle/oauth-mcp-proxy v1.0.3
 	github.com/mark3labs/mcp-go v0.42.0
 	github.com/trinodb/trino-go-client v0.328.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/Vungle/oauth-mcp-proxy v1.0.2 h1:Ms721N1EbyIazqdohC5ZH6OK//QTOIVWqtPnqYplPu4=
-github.com/Vungle/oauth-mcp-proxy v1.0.2/go.mod h1:/Hato9I2XT25X/oxoAn7DGGIBU8cnAztLqyv0kyZOHM=
+github.com/Vungle/oauth-mcp-proxy v1.0.3 h1:2TIyAYDcpqViW1mRjpFwoXTnF5QiIwTBWph17wnkE3I=
+github.com/Vungle/oauth-mcp-proxy v1.0.3/go.mod h1:/Hato9I2XT25X/oxoAn7DGGIBU8cnAztLqyv0kyZOHM=
 github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26 h1:3YVZUqkoev4mL+aCwVOSWV4M7pN+NURHL38Z2zq5JKA=
 github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26/go.mod h1:ymXt5bw5uSNu4jveerFxE0vNYxF8ncqbptntMaFMg3k=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -41,7 +41,7 @@ func (h *TrinoHandlers) ExecuteQuery(ctx context.Context, request mcp.CallToolRe
 	}
 
 	// Execute the query - SQL injection protection is handled within the client
-	results, err := h.TrinoClient.ExecuteQuery(query)
+	results, err := h.TrinoClient.ExecuteQuery(ctx, query)
 	if err != nil {
 		log.Printf("Error executing query: %v", err)
 		mcpErr := fmt.Errorf("query execution failed: %w", err)
@@ -62,7 +62,7 @@ func (h *TrinoHandlers) ExecuteQuery(ctx context.Context, request mcp.CallToolRe
 // ListCatalogs handles catalog listing
 func (h *TrinoHandlers) ListCatalogs(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 
-	catalogs, err := h.TrinoClient.ListCatalogs()
+	catalogs, err := h.TrinoClient.ListCatalogs(ctx)
 	if err != nil {
 		log.Printf("Error listing catalogs: %v", err)
 		mcpErr := fmt.Errorf("failed to list catalogs: %w", err)
@@ -95,7 +95,7 @@ func (h *TrinoHandlers) ListSchemas(ctx context.Context, request mcp.CallToolReq
 		catalog = catalogParam
 	}
 
-	schemas, err := h.TrinoClient.ListSchemas(catalog)
+	schemas, err := h.TrinoClient.ListSchemas(ctx, catalog)
 	if err != nil {
 		log.Printf("Error listing schemas: %v", err)
 		mcpErr := fmt.Errorf("failed to list schemas: %w", err)
@@ -131,7 +131,7 @@ func (h *TrinoHandlers) ListTables(ctx context.Context, request mcp.CallToolRequ
 		schema = schemaParam
 	}
 
-	tables, err := h.TrinoClient.ListTables(catalog, schema)
+	tables, err := h.TrinoClient.ListTables(ctx, catalog, schema)
 	if err != nil {
 		log.Printf("Error listing tables: %v", err)
 		mcpErr := fmt.Errorf("failed to list tables: %w", err)
@@ -177,7 +177,7 @@ func (h *TrinoHandlers) GetTableSchema(ctx context.Context, request mcp.CallTool
 	}
 	table = tableParam
 
-	tableSchema, err := h.TrinoClient.GetTableSchema(catalog, schema, table)
+	tableSchema, err := h.TrinoClient.GetTableSchema(ctx, catalog, schema, table)
 	if err != nil {
 		log.Printf("Error getting table schema: %v", err)
 		mcpErr := fmt.Errorf("failed to get table schema: %w", err)
@@ -218,7 +218,7 @@ func (h *TrinoHandlers) ExplainQuery(ctx context.Context, request mcp.CallToolRe
 	}
 
 	// Execute the explain query
-	results, err := h.TrinoClient.ExplainQuery(query, format)
+	results, err := h.TrinoClient.ExplainQuery(ctx, query, format)
 	if err != nil {
 		log.Printf("Error explaining query: %v", err)
 		mcpErr := fmt.Errorf("query explanation failed: %w", err)

--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Vungle/mcp-trino/internal/config"
+	oauth "github.com/Vungle/oauth-mcp-proxy"
 	_ "github.com/trinodb/trino-go-client/trino"
 )
 
@@ -217,8 +218,26 @@ func sanitizeQueryForKeywordDetection(query string) string {
 	return strings.TrimSpace(query)
 }
 
+// getQueryUsername returns the username of the user executing the query if present in context
+func getQueryUsername(ctx context.Context) string {
+	user, exists := oauth.GetUserFromContext(ctx)
+	if !exists || user == nil {
+		return "mcp-trino-user"
+	}
+	if user.Username != "" {
+		return user.Username
+	}
+	if user.Email != "" {
+		return user.Email
+	}
+	if user.Subject != "" {
+		return user.Subject
+	}
+	return "mcp-trino-user"
+}
+
 // ExecuteQuery executes a SQL query and returns the results
-func (c *Client) ExecuteQuery(query string) ([]map[string]interface{}, error) {
+func (c *Client) ExecuteQuery(ctx context.Context, query string) ([]map[string]interface{}, error) {
 	// Strip trailing semicolon that Trino doesn't allow
 	query = strings.TrimSuffix(strings.TrimSpace(query), ";")
 
@@ -227,12 +246,18 @@ func (c *Client) ExecuteQuery(query string) ([]map[string]interface{}, error) {
 		return nil, fmt.Errorf("security restriction: only SELECT, SHOW, DESCRIBE, and EXPLAIN queries are allowed. " +
 			"Set TRINO_ALLOW_WRITE_QUERIES=true to enable write operations (at your own risk)")
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
-	defer cancel()
-
+	// get User from context - if present
+	userName := getQueryUsername(ctx)
 	// Execute the query
-	rows, err := c.db.QueryContext(ctx, query)
+	// To pass per-query user information to Trino,
+	// you have to add a NamedArg to the query parameters where the key is X-Trino-User.
+	// This parameter is used by the driver to inform Trino about the user executing the query
+	// regardless of the authentication method for the actual connection, and its value is NOT passed to the query.
+	rows, err := c.db.QueryContext(
+		ctx,
+		query,
+		sql.Named("X-Trino-User", userName),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query execution failed: %w", err)
 	}
@@ -287,8 +312,8 @@ func (c *Client) ExecuteQuery(query string) ([]map[string]interface{}, error) {
 }
 
 // ListCatalogs returns a list of available catalogs
-func (c *Client) ListCatalogs() ([]string, error) {
-	results, err := c.ExecuteQuery("SHOW CATALOGS")
+func (c *Client) ListCatalogs(ctx context.Context) ([]string, error) {
+	results, err := c.ExecuteQuery(ctx, "SHOW CATALOGS")
 	if err != nil {
 		return nil, err
 	}
@@ -309,13 +334,13 @@ func (c *Client) ListCatalogs() ([]string, error) {
 }
 
 // ListSchemas returns a list of schemas in the specified catalog
-func (c *Client) ListSchemas(catalog string) ([]string, error) {
+func (c *Client) ListSchemas(ctx context.Context, catalog string) ([]string, error) {
 	if catalog == "" {
 		catalog = c.config.Catalog
 	}
 
 	query := fmt.Sprintf("SHOW SCHEMAS FROM %s", catalog)
-	results, err := c.ExecuteQuery(query)
+	results, err := c.ExecuteQuery(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +361,7 @@ func (c *Client) ListSchemas(catalog string) ([]string, error) {
 }
 
 // ListTables returns a list of tables in the specified catalog and schema
-func (c *Client) ListTables(catalog, schema string) ([]string, error) {
+func (c *Client) ListTables(ctx context.Context, catalog string, schema string) ([]string, error) {
 	if catalog == "" {
 		catalog = c.config.Catalog
 	}
@@ -345,7 +370,7 @@ func (c *Client) ListTables(catalog, schema string) ([]string, error) {
 	}
 
 	query := fmt.Sprintf("SHOW TABLES FROM %s.%s", catalog, schema)
-	results, err := c.ExecuteQuery(query)
+	results, err := c.ExecuteQuery(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +391,7 @@ func (c *Client) ListTables(catalog, schema string) ([]string, error) {
 }
 
 // GetTableSchema returns the schema of a table
-func (c *Client) GetTableSchema(catalog, schema, table string) ([]map[string]interface{}, error) {
+func (c *Client) GetTableSchema(ctx context.Context, catalog, schema, table string) ([]map[string]interface{}, error) {
 	// Resolve catalog/schema/table parameters first
 	parts := strings.Split(table, ".")
 	if len(parts) == 3 {
@@ -400,11 +425,11 @@ func (c *Client) GetTableSchema(catalog, schema, table string) ([]map[string]int
 
 	// Build and execute query with resolved parameters
 	query := fmt.Sprintf("DESCRIBE %s.%s.%s", catalog, schema, table)
-	return c.ExecuteQuery(query)
+	return c.ExecuteQuery(ctx, query)
 }
 
 // ExplainQuery returns the query execution plan for a given SQL query
-func (c *Client) ExplainQuery(query string, format string) ([]map[string]interface{}, error) {
+func (c *Client) ExplainQuery(ctx context.Context, query string, format string) ([]map[string]interface{}, error) {
 	// Build EXPLAIN query with optional TYPE format (LOGICAL|DISTRIBUTED|VALIDATE|IO)
 	explainQuery := "EXPLAIN"
 	if f := strings.ToUpper(strings.TrimSpace(format)); f != "" {
@@ -417,7 +442,7 @@ func (c *Client) ExplainQuery(query string, format string) ([]map[string]interfa
 	}
 	explainQuery = fmt.Sprintf("%s %s", explainQuery, query)
 
-	return c.ExecuteQuery(explainQuery)
+	return c.ExecuteQuery(ctx, explainQuery)
 }
 
 // sanitizeConnectionError removes sensitive information from connection errors

--- a/internal/trino/client.go
+++ b/internal/trino/client.go
@@ -256,7 +256,9 @@ func (c *Client) ExecuteQuery(ctx context.Context, query string) ([]map[string]i
 	rows, err := c.db.QueryContext(
 		ctx,
 		query,
-		sql.Named("X-Trino-User", userName),
+		sql.Named("X-Trino-Client-Tags", userName),
+		sql.Named("X-Trino-Client-Info", userName),
+		sql.Named("X-Trino-Source", userName),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query execution failed: %w", err)


### PR DESCRIPTION
The Trino [go-client](https://github.com/trinodb/trino-go-client?tab=readme-ov-file#system-access-control-and-per-query-user-information) supports sending user info to trino cluster using a special request argument to sql.Query/sql.QueryContext . 

Since Authenticated user identity is present in context using the oauth-mcp-proxy oauth.WithUser function, it should be possible to extract the user from the profile. 